### PR TITLE
Initialize VS Code extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+out
+*.vsix
+.vscode-test

--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
 # JSONBro
+
+JSONBro is a simple Visual Studio Code extension template for working with JSON files.
+
+## Development
+
+Install dependencies and compile the extension:
+
+```bash
+npm install
+npm run compile
+```
+
+Launch the extension in a development window by pressing `F5` in VS Code.
+
+## Packaging
+
+To create an installable `.vsix` package run:
+
+```bash
+npm run package
+```
+
+This will create a `jsonbro-x.y.z.vsix` file that can be installed from VS Code via the Extensions: Install from VSIX command.
+

--- a/package.json
+++ b/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "jsonbro",
+  "displayName": "JSONBro",
+  "description": "A simple VS Code extension for working with JSON.",
+  "version": "0.0.1",
+  "publisher": "your-name",
+  "engines": {
+    "vscode": "^1.81.0"
+  },
+  "categories": [
+    "Other"
+  ],
+  "activationEvents": [
+    "onCommand:extension.sayHello"
+  ],
+  "main": "./out/extension.js",
+  "contributes": {
+    "commands": [
+      {
+        "command": "extension.sayHello",
+        "title": "JSONBro: Say Hello"
+      }
+    ]
+  },
+  "scripts": {
+    "vscode:prepublish": "npm run compile",
+    "compile": "tsc -p ./",
+    "watch": "tsc -watch -p ./",
+    "package": "vsce package"
+  },
+  "devDependencies": {
+    "@types/node": "^16.11.7",
+    "@types/vscode": "^1.81.0",
+    "typescript": "^5.0.2",
+    "vsce": "^2.17.0"
+  }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,0 +1,11 @@
+import * as vscode from 'vscode';
+
+export function activate(context: vscode.ExtensionContext) {
+    let disposable = vscode.commands.registerCommand('extension.sayHello', () => {
+        vscode.window.showInformationMessage('Hello from JSONBro!');
+    });
+
+    context.subscriptions.push(disposable);
+}
+
+export function deactivate() {}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es6",
+    "outDir": "out",
+    "lib": ["es6"],
+    "sourceMap": true,
+    "rootDir": "src",
+    "strict": true
+  },
+  "exclude": ["node_modules", ".vscode-test"]
+}


### PR DESCRIPTION
This pull request introduces the initial setup for the `JSONBro` Visual Studio Code extension. The changes include adding the core functionality, configuration, and documentation necessary to get started with the extension.

### Core functionality:

* [`src/extension.ts`](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626R1-R11): Implemented the `activate` function to register a "Say Hello" command (`extension.sayHello`) that displays a greeting message in VS Code. Added a `deactivate` function placeholder.

### Configuration:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R1-R37): Added metadata and configuration for the extension, including name, description, activation events, commands, and development scripts. Configured dependencies for TypeScript, VS Code types, and packaging tools.

### Documentation:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R2-R25): Added a description of the extension, development instructions, and packaging steps to create an installable `.vsix` file.