### PR TITLE
Fix maximize button in order to zoom in full screen a selected pane

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "jsonbro",
   "displayName": "JSONBro",
   "description": "A simple VS Code extension for working with JSON.",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "publisher": "LucianDCrainic",
   "icon": "images/icon.png",
   "engines": {

--- a/src/webview/controller.ts
+++ b/src/webview/controller.ts
@@ -873,7 +873,12 @@ export class WebviewController {
             return;
         }
 
-        button.addEventListener('click', () => {
+        // Remove any existing listener by cloning and replacing the button
+        const newButton = button.cloneNode(true) as HTMLElement;
+        button.parentNode?.replaceChild(newButton, button);
+
+        // Add the click listener to the new button
+        newButton.addEventListener('click', () => {
             this.toggleMaximizePanel(panelId);
         });
     }


### PR DESCRIPTION
This pull request includes a minor version bump and an improvement to event listener management for a UI button in the webview controller. The most notable change is the safer handling of click event listeners to prevent duplicate listeners when toggling the maximize panel action.

Version update:

* Bumped the extension version in `package.json` from `0.2.7` to `0.2.8`.

UI event handling improvement:

* In `src/webview/controller.ts`, updated the logic for attaching the maximize button's click event: the button is now cloned and replaced before adding the event listener, ensuring no duplicate listeners are attached.